### PR TITLE
Fix deprecation warning for hostfile config

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-hostfile = hosts
+inventory = ./hosts
 nocows = 1
 vault_password_file = .vault_pass
 roles_path = vendor


### PR DESCRIPTION
"[DEPRECATION WARNING]: [defaults]hostfile option, The key is misleading as it can also be a list of
hosts, a directory or a list of paths , use [defaults] inventory=/path/to/file|dir instead. This
feature will be removed in version 2.8. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg"

cheers!